### PR TITLE
Actualizar calendario

### DIFF
--- a/static/calendario_2022_2.csv
+++ b/static/calendario_2022_2.csv
@@ -1,4 +1,4 @@
-Fecha teórica,Tema teórica,Fecha de práctica,Tema práctica,Lab Presentado,Lab Entregado
+Fecha teórica,Tema teórica,Fecha de práctica,Tema práctica,Lab Presentado,Lab Entregado el día anterior a las 23:59
 22/8,"Introducción (Torres Axiomaticas, Arquitecturas comp y su relacion lenguajes, paradigmas, features de leng de programación)
 ver https://www.youtube.com/watch?v=wSdV1M7n4gQ",24/8,"Herramientas
 -introducción a la practica
@@ -15,22 +15,21 @@ Lex y flex",7/9,"Intro teórica lab
 Ejercicio 00
 Entrega ej 01",2: Lexers,1: Autómatas
 12/9,"Análisis Sintáctico: introducción
-Gramaticas, derivaciones",14/9,"Ej adicionales
-Consultas",,
-19/9,"Análisis Sintáctico:  
-LL(1), Primero(), Siguienete(), Tabla Parsing",21/9,"Intro teórica lab
+Gramaticas, derivaciones",14/9,Consultas,,
+19/9,-,21/9,FERIADO,,2: Lexers
+26/9,"Análisis Sintáctico:  
+LL(1), Primero(), Siguienete(), Tabla Parsing",28/9,"Intro teórica lab
+Ejercicio 00",3: Parser desc rec LUA,
+3/10,"Analisis Sintactico (Partes 1, 2, 3)",5/10,"Intro teórica lab
 Ejercicio 00
-Entrega ej 01",3: Parser desc rec LUA,2: Lexers
-26/9,"Analisis Sintactico (Partes 1, 2, 3)",28/9,Consultas,,
-3/10,"Análisis Sintáctico: Teórico LR Simple,LR Canonico,LALR",5/10,"Intro teórica lab
-Ejercicio 00
-Entrega ej 01",4: parseo LL1,3: Parser desc rec LUA
+Entrega lab completo",4: parseo LL1,
 10/10,FERIADO,12/10,"Intro teórica lab
 Ejercicio 00
-Entrega ej 01",5: intérprete,
-17/10,[Definiendo],19/10,"Intro teórica lab
+Entrega ej 01",5: intérprete,"3: Parser desc rec LUA
+4: parseo LL1"
+17/10,"Análisis Sintáctico: Teórico LR Simple,LR Canonico,LALR",19/10,"Intro teórica lab
 Ejercicio 00
-Entrega ej 01",6: lex-yacc,4: parseo LL1
+Entrega ej 01",6: lex-yacc,
 24/10,[Definiendo],26/10,Consultas,,5: intérprete
 31/10,[Definiendo],2/11,"Intro teórica lab
 Ejercicio 00


### PR DESCRIPTION
Novedades:
- Se aclara que los labs se entregan el día anterior a las 23:59 al que figura en la columna de fecha de práctica
- Se agregó el FERIADO del 21/9, 
  - se pospuso la práctica 4 una semana
  - se eliminó la clase de consulta del 28/9
  - Se pospuso la entrega del lab 3 una semana para que el plazo siga siendo de 2 semanas
- Se **adelantó** la entrega del lab 4 para que tengan 1 semana de plazo recomendado en vez de 2.
- Se pospusieron las clases de la teórica 1 semana para reflejar la suspensión del lunes

El objetivo es conservar los tiempos asignados al TP final para estimular a los alumnos a completar el TP final durante la cursada.