### PR TITLE
Nueva modificación calendario

### DIFF
--- a/static/calendario_2022_2.csv
+++ b/static/calendario_2022_2.csv
@@ -22,20 +22,18 @@ LL(1), Primero(), Siguienete(), Tabla Parsing",28/9,"Intro teórica lab
 Ejercicio 00",3: Parser desc rec LUA,
 3/10,"Analisis Sintactico (Partes 1, 2, 3)",5/10,"Intro teórica lab
 Ejercicio 00
-Entrega lab completo",4: parseo LL1,
-10/10,FERIADO,12/10,"Intro teórica lab
-Ejercicio 00
-Entrega ej 01",5: intérprete,"3: Parser desc rec LUA
-4: parseo LL1"
+Entrega ej 01",5: intérprete,
+10/10,FERIADO,12/10,"Consultas, Presentación TP final",,
 17/10,"Análisis Sintáctico: Teórico LR Simple,LR Canonico,LALR",19/10,"Intro teórica lab
 Ejercicio 00
-Entrega ej 01",6: lex-yacc,
-24/10,[Definiendo],26/10,Consultas,,5: intérprete
-31/10,[Definiendo],2/11,"Intro teórica lab
+Entrega ej 01",4: parseo LL1,"3: Parser desc rec LUA
+5: intérprete"
+24/10,[Definiendo],26/10,"Intro teórica lab
 Ejercicio 00
-Entrega ej 01",7: jsonasm,
-7/11,[Definiendo],9/11,Intro TP final,,6: lex-yacc
-14/11,[Definiendo],16/11,TP final,,7: jsonasm
-21/11,FERIADO,23/11,TP final,,
-28/11,[Definiendo],30/11,TP final,,
-5/12,[Definiendo],7/12,TP final,,
+Entrega ej 01",6: Compilador a jsonasm,4: parseo LL1
+31/10,[Definiendo],2/11,Charlas relámpago obligatorias TPF,,
+7/11,[Definiendo],9/11,standup TPF,,6: Compilador a jsonasm
+14/11,[Definiendo],16/11,standup TPF,,
+21/11,FERIADO,23/11,standup TPF,,
+28/11,[Definiendo],30/11,standup TPF,,
+5/12,[Definiendo],7/12,Entrega parcial TPF y explicación al resto de la clase,,


### PR DESCRIPTION
Cambios:
- El 5/10 se presenta el laboratorio de intérpretes
- Se pospone la práctica de parsers LL1 al 19/10
- Se elimina el laboratorio de bison
- Cambia la fecha de presentación y entrega del laboratorio 6: compilación a jsonasm.
- Se adelanta la presentación del TPF al 12/10
- **Postponer entrega lab 3 una semana**
- Fechas relevantes del TPF se agregaron a Noviembre